### PR TITLE
Add F-05E Fujitsu ArrowsTab entry

### DIFF
--- a/db_init.sql
+++ b/db_init.sql
@@ -1486,4 +1486,11 @@ INSERT INTO supported_devices(device_id, device, build_id, check_property_name, 
   INSERT INTO device_address(device_id, name, value) VALUES(201, 'commit_creds', '0xc00bcfe0');
   INSERT INTO device_address(device_id, name, value) VALUES(201, 'ptmx_fops', '0xc0b0b130');
 
+INSERT INTO supported_devices(device_id, device, build_id, check_property_name, check_property_value) VALUES(201, 'F-05E', 'V11R35A', NULL, NULL);
+  INSERT INTO device_address(device_id, name, value) VALUES(201, 'ptmx_fops', '0xc0b1e948');
+  INSERT INTO device_address(device_id, name, value) VALUES(201, 'prepare_kernel_cred', '0xc0090d78');
+  INSERT INTO device_address(device_id, name, value) VALUES(201, 'commit_creds', '0xc0090734');
+  INSERT INTO device_address(device_id, name, value) VALUES(201, 'remap_pfn_range', '0xc00e2064');
+
+
 COMMIT;

--- a/device_database.h
+++ b/device_database.h
@@ -202,6 +202,7 @@ typedef enum {
   DEVICE_LGL23_V10d,
   DEVICE_GTI9195_MF5,
   DEVICE_P03E_10_1010,
+  DEVICE_F05E_V11R35A,
 } device_id_t;
 
 #define DEVICE_SYMBOL(name)     #name


### PR DESCRIPTION
The patch adds Fujitsu Arrows Tab F-05E entry.
http://www.fmworld.net/product/phone/f-05e/

It seems to work with backdoor_mmap_tools.
